### PR TITLE
Fix: Lint Restrictions + Github Actions

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -4,6 +4,7 @@ module.exports = {
 		es2021: true,
 		node: true,
 	},
+	ignorePatterns: ["types/**", "dist/**"],
 	extends: [
 		"eslint:recommended",
 		"plugin:jsx-a11y/strict",

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: pnpm/action-setup@v2
+        with:
+          version: 7.27.0
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
       - name: Run lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,10 +2,12 @@ name: Lint
 
 on:
   pull_request:
-    branches: [main]
+    branches:
+      - "*"
 
 jobs:
-  build:
+  initialize:
+    name: initialize
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -14,5 +16,10 @@ jobs:
           version: 7.27.0
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
+  lint:
+    needs: initialize
+    runs-on: ubuntu-latest
+    name: lint
+    steps:
       - name: Run lint
         run: npm run lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: Lint
+name: Validate
 
 on:
   pull_request:
@@ -6,7 +6,7 @@ on:
       - "*"
 
 jobs:
-  validate:
+  lint-and-typecheck:
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: pnpm/action-setup@v2
       - name: Install Dependencies
-        run: npm ci
+        run: pnpm install --frozen-lockfile
       - name: Run lint
         run: npm run lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,20 +6,21 @@ on:
       - "*"
 
 jobs:
-  initialize:
-    name: initialize
+  validate:
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        pnpm-version: [7.27.0]
+
     steps:
       - uses: actions/checkout@v2
       - uses: pnpm/action-setup@v2
         with:
-          version: 7.27.0
+          version: ${{ matrix.pnpm-version }}
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
-  lint:
-    needs: initialize
-    runs-on: ubuntu-latest
-    name: lint
-    steps:
-      - name: Run lint
+      - name: Lint
         run: npm run lint
+      - name: Typecheck
+        run: npm run typecheck

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,5 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Install Dependencies
+        run: npm ci
       - name: Run lint
         run: npm run lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: Validate
+name: validate
 
 on:
   pull_request:

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
 		"@rive-app/canvas": "^1.0.98",
 		"solid-js": "^1.5.7"
 	},
+	"packageManager": "^pnpm@7.27.0",
 	"devDependencies": {
 		"@babel/core": "^7.20.12",
 		"@typescript-eslint/eslint-plugin": "^5.39.0",


### PR DESCRIPTION
sets up github actions to run correctly and adds the build output folders (dist and types) to the eslint ignore list